### PR TITLE
Add Arch Linux support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,9 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
+    - name: ArchLinux
+      versions:
+        - all
   galaxy_tags:
     - system
     - web

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,0 +1,4 @@
+---
+__htpasswd_required_packages:
+  - apache
+  - python-passlib


### PR DESCRIPTION
Add new vars/Archlinux.yml which lists the two equivalent packages to the ones installed for Debian.yml already.

I've tested it locally (hopefully correctly). Not sure if you intend to support Arch at all given the comment in the readme, but I thought I'd try.

Thanks for making this role available :-)